### PR TITLE
Make library and examples compile on Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -112,16 +112,16 @@ def allegroLibrary():
     allegro_store[0] = library
     return allegro_store[0]
 
-def makeExample(name, source):
+def makeExample(source):
     env = allegro4Environment()
-    env.VariantDir('build/examples', 'examples')
-    return env.Program(name, map(lambda x: 'build/examples/%s' % x, source))
+    env.VariantDir('build/examples', 'examples', duplicate = False)
+    return env.Program('build/examples/' + source)
 
 def stars():
-    return makeExample('exstars', ['exstars.c'])
+    return makeExample('exstars.c')
 
 def shade():
-    return makeExample('exshade', ['exshade.c'])
+    return makeExample('exshade.c')
 
 
 def demos():
@@ -132,6 +132,6 @@ def demos():
 examples = glob.glob("examples/*.c")
 for example in examples:
     name = re.sub(r"examples/(.*?)\.c", r"\1", example)
-    makeExample(name, [name + ".c"])
+    makeExample(name + ".c")
 
 demos()

--- a/allegro4/datafile.c
+++ b/allegro4/datafile.c
@@ -22,6 +22,7 @@
 
 #include "allegro.h"
 #include "include/internal/aintern.h"
+#include "include/internal/alconfig.h"
 
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_font.h>

--- a/allegro4/include/internal/alconfig.h
+++ b/allegro4/include/internal/alconfig.h
@@ -42,3 +42,32 @@
    #define FA_NONE         0
    #define FA_ALL          (~FA_NONE)
 
+/* endian-independent 3-byte accessor macros */
+#ifdef ALLEGRO_LITTLE_ENDIAN
+
+   #define READ3BYTES(p)  ((*(unsigned char *)(p))               \
+                           | (*((unsigned char *)(p) + 1) << 8)  \
+                           | (*((unsigned char *)(p) + 2) << 16))
+
+   #define WRITE3BYTES(p,c)  ((*(unsigned char *)(p) = (c)),             \
+                              (*((unsigned char *)(p) + 1) = (c) >> 8),  \
+                              (*((unsigned char *)(p) + 2) = (c) >> 16))
+
+#elif defined ALLEGRO_BIG_ENDIAN
+
+   #define READ3BYTES(p)  ((*(unsigned char *)(p) << 16)         \
+                           | (*((unsigned char *)(p) + 1) << 8)  \
+                           | (*((unsigned char *)(p) + 2)))
+
+   #define WRITE3BYTES(p,c)  ((*(unsigned char *)(p) = (c) >> 16),       \
+                              (*((unsigned char *)(p) + 1) = (c) >> 8),  \
+                              (*((unsigned char *)(p) + 2) = (c)))
+
+#elif defined SCAN_DEPEND
+
+   #define READ3BYTES(p)
+   #define WRITE3BYTES(p,c)
+
+#else
+   #error endianess not defined
+#endif


### PR DESCRIPTION
With this PR the library compiles on Ubuntu 20.04 with scons 3.1.2 and allegro 5.2.6 (both packages from the Ubuntu standard repository). The build script has become a bit simpler for compiling the examples.