### PR TITLE
GitHub workflow, typos, Windows, shared library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,13 @@ jobs:
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
-    - name: 💾 Cache downloaded Pacman packages on Windows
+    - name: 💾 Cache dependencies on Windows
       if: runner.os == 'Windows'
       uses: actions/cache@v4
       with:
-        path: C:\msys64\var\cache\pacman\pkg
+        path: |
+          C:\msys64\var\cache\pacman\pkg
+          C:\vcpkg\installed
         key: build-dep-windows
     - name: 💾 Cache dependencies on MacOS
       if: runner.os == 'macOS'
@@ -34,22 +36,38 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -qq -y -o=Dpkg::Use-Pty=0 liballegro5-dev scons
+    - name: Setup MSVC
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
     - name: 🔍 Add MSYS2 to path on Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "C:\msys64\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: 🪟 Install dependencies on Windows
+    - name: 🪟 Install msys2 dependencies on Windows
       if: runner.os == 'Windows'
       run: |
         pacman --noconfirm -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-scons mingw-w64-ucrt-x86_64-allegro mingw-w64-ucrt-x86_64-pkgconf
+    - name: 🪟 Set up environment variables on Windows
+      if: runner.os == 'Windows'
+      run: |
+        echo "VCPKG_ROOT=C:/vcpkg" >> $GITHUB_ENV
+        echo "MSYSTEM=UCRT64" >> $GITHUB_ENV
+    - name: 🪟 Install vcpkg dependencies on Windows
+      if: runner.os == 'Windows'
+      run: vcpkg install allegro5
+    - name: ⚒ Build static with Visual Studio on Windows
+      if: runner.os == 'Windows'
+      run: scons -j 1
+    - name: ⚒ Build shared with Visual Studio on Windows
+      if: ${{ runner.os == 'Windows' && !cancelled() }}
+      run: |
+        scons -j 1 build_shared=1
         sed -i "s/env = Environment(ENV = os.environ)/env = Environment(tools=['mingw'], ENV = os.environ)/" SConstruct
     - name: ⚒ Build static
-      env:
-        MSYSTEM: UCRT64
+      if: ${{ !cancelled() }}
       run: scons -j 1
     - name: ⚒ Build shared
-      env:
-        MSYSTEM: UCRT64
+      if: ${{ !cancelled() }}
       run: scons -j 1 build_shared=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+    - name: 💾 Cache downloaded Pacman packages on Windows
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: C:\msys64\var\cache\pacman\pkg
+        key: build-dep-windows
+    - name: 💾 Cache dependencies on MacOS
+      if: runner.os == 'macOS'
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/Homebrew/downloads
+        key: build-dep-macos
+    - name: 🍺 Install dependencies on MacOS
+      if: runner.os == 'macOS'
+      run: env HOMEBREW_NO_AUTO_UPDATE=1 brew install allegro scons
+    - name: 🐧 Install dependencies on Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get install -qq -y -o=Dpkg::Use-Pty=0 liballegro5-dev scons
+    - name: 🔍 Add MSYS2 to path on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "C:\msys64\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: 🪟 Install dependencies on Windows
+      if: runner.os == 'Windows'
+      run: |
+        pacman --noconfirm -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-scons mingw-w64-ucrt-x86_64-allegro mingw-w64-ucrt-x86_64-pkgconf
+        sed -i "s/env = Environment(ENV = os.environ)/env = Environment(tools=['mingw'], ENV = os.environ)/" SConstruct
+    - name: ⚒ Build static
+      env:
+        MSYSTEM: UCRT64
+      run: scons -j 1
+    - name: ⚒ Build shared
+      env:
+        MSYSTEM: UCRT64
+      run: scons -j 1 build_shared=1

--- a/SConstruct
+++ b/SConstruct
@@ -36,6 +36,11 @@ def defaultEnvironment():
     env = Environment(ENV = os.environ)
     #env.Replace(CC = "clang")
     env.Append(CCFLAGS = ['-g3', '-Wall'])
+    if env['PLATFORM'] == 'darwin':
+        env.Append(CPPPATH=['/opt/homebrew/include'])
+        env.Append(LIBPATH=['/opt/homebrew/lib'])
+        env.Append(LINKFLAGS=['-rpath', '/opt/homebrew/lib'])
+
     if not build_shared:
         env.MergeFlags({'CPPDEFINES': 'ALLEGRO425_STATICLINK'})
     return env
@@ -73,7 +78,7 @@ class Cache:
         if self.allegro_libs is None:
             self.allegro_libs = ["allegro", "allegro_primitives",
 		"allegro_image", "allegro_font", "allegro_audio",
-		"allegro_acodec"]
+		"allegro_acodec", "allegro_main"]
 
             tests = {
                 "CheckPKGConfig": CheckPKGConfig,

--- a/SConstruct
+++ b/SConstruct
@@ -35,11 +35,19 @@ else:
 def defaultEnvironment():
     env = Environment(ENV = os.environ)
     #env.Replace(CC = "clang")
-    env.Append(CCFLAGS = ['-g3', '-Wall'])
+    env.Append(LIBPATH=[f'#{prefix}/allegro'])
+    if 'gcc' in env['TOOLS']:
+        env.Append(CCFLAGS = ['-g3', '-Wall'])
     if env['PLATFORM'] == 'darwin':
         env.Append(CPPPATH=['/opt/homebrew/include'])
         env.Append(LIBPATH=['/opt/homebrew/lib'])
         env.Append(LINKFLAGS=['-rpath', '/opt/homebrew/lib'])
+    elif 'msvc' in env['TOOLS']:
+        vcpkg_root = os.environ['VCPKG_ROOT'].replace('\\', '/')
+        env.Append(CCFLAGS=['/std:c11']) # if using _Thread_local
+        env.Append(CPPDEFINES=['ALLEGRO_NO_MAGIC_MAIN']) # to avoid forcing main() entry point for DLL
+        env.Append(CPPPATH=[f'{vcpkg_root}/installed/x64-windows/include'])
+        env.Append(LIBPATH=[f'{vcpkg_root}/installed/x64-windows/lib'])
 
     if not build_shared:
         env.MergeFlags({'CPPDEFINES': 'ALLEGRO425_STATICLINK'})
@@ -102,7 +110,9 @@ def allegro4Environment():
 
     env = cache.get_env()
 
-    env.Prepend(LIBS = [allegroLibrary(), 'm'])
+    env.Prepend(LIBS = [allegroLibrary()])
+    if 'gcc' in env['TOOLS']:
+        env.Append(LIBS = ['m'])
     # env.Prepend(LIBS = [allegroLibrary()])
     env.Append(CPPPATH = ['#allegro4'])
     return env

--- a/allegro4/SConscript
+++ b/allegro4/SConscript
@@ -2,7 +2,7 @@ Import('env')
 
 source = Split("""allegro.c math3d.c math.c file.c unicode.c color.c clip3df.c
 datafile.c lzss.c dataregi.c gui.c guiproc.c font.c quat.c sound.c palette.c
-ufile.c fsel.c
+ufile.c fsel.c inline.c
 """)
 library = env.StaticLibrary('allegro4-to-5', source)
 Return('library')

--- a/allegro4/SConscript
+++ b/allegro4/SConscript
@@ -1,8 +1,12 @@
-Import('env')
+Import(['env', 'shared'])
 
 source = Split("""allegro.c math3d.c math.c file.c unicode.c color.c clip3df.c
 datafile.c lzss.c dataregi.c gui.c guiproc.c font.c quat.c sound.c palette.c
 ufile.c fsel.c inline.c
 """)
-library = env.StaticLibrary('allegro4-to-5', source)
+
+if (shared):
+	library = env.SharedLibrary('allegro4-to-5', source)
+else:
+	library = env.StaticLibrary('allegro4-to-5', source)
 Return('library')

--- a/allegro4/SConscript
+++ b/allegro4/SConscript
@@ -5,8 +5,10 @@ datafile.c lzss.c dataregi.c gui.c guiproc.c font.c quat.c sound.c palette.c
 ufile.c fsel.c inline.c
 """)
 
+name = 'allegro4-to-5'
 if (shared):
-	library = env.SharedLibrary('allegro4-to-5', source)
+	library = env.SharedLibrary(name, source)
 else:
-	library = env.StaticLibrary('allegro4-to-5', source)
-Return('library')
+	library = env.StaticLibrary(name, source)
+
+Return('name')

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -2,10 +2,6 @@
 #include <stdlib.h>
 #include "allegro.h"
 
-int AL_RAND(){
-    return rand();
-}
-
 #include <allegro5/allegro5.h>
 #include <allegro5/allegro_primitives.h>
 #include <allegro5/allegro_image.h>

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -1760,7 +1760,7 @@ void set_keyboard_rate(int delay, int repeat){
 
 void set_config_int(AL_CONST char *section, AL_CONST char *name, int val){
    char sval[1024];
-   snprintf(sval, sizeof val, "%d", val);
+   snprintf(sval, sizeof sval, "%d", val);
    set_config_string(section, name, sval);
 }
 

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -1916,3 +1916,21 @@ void arc(BITMAP * buffer, int x, int y, fixed ang1, fixed ang2, int r, int color
     draw_into(buffer);
     al_draw_arc(x, y, r, fixangle_to_radians(ang1), fixangle_to_radians(ang2), a5color(color, current_depth), 1);
 }
+
+#ifdef ALLEGRO_WINDOWS
+/* _al_drive_exists:
+ *  Checks whether the specified drive is valid.
+ */
+int _al_drive_exists(int drive)
+{
+   return GetLogicalDrives() & (1 << drive);
+}
+
+/* _al_getdrive:
+ *  Returns the current drive number (0=A, 1=B, etc).
+ */
+int _al_getdrive(void)
+{
+    return _getdrive() - 1;
+}
+#endif

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -565,12 +565,12 @@ void set_color_conversion(int mode){
 
 int set_gfx_mode(int card, int width, int height, int virtualwidth, int virtualheight){
     int i;
-    if (card == GFX_TEXT) {
-        if (display)
-            al_destroy_display(display);
+    if (display) {
+        al_destroy_display(display);
         display = NULL;
-        return 0;
     }
+    if (card == GFX_TEXT)
+        return 0;
     display = al_create_display(width, height);
     if (display) {
         if (window_title[0]) {
@@ -589,8 +589,6 @@ int set_gfx_mode(int card, int width, int height, int virtualwidth, int virtualh
             al_destroy_display(display);
             display = NULL;
         }
-    }
-    if (display) {
         al_register_event_source(system_event_queue, al_get_display_event_source(display));
         return 0;
     }

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -60,6 +60,7 @@ GFX_DRIVER _gfx_driver = {0, "A5", "A5", "A5", 0, 0, 0, 0, 0, 0, 0, 0};
 GFX_DRIVER *gfx_driver = &_gfx_driver;
 void (*keyboard_lowlevel_callback)(int scancode);
 BITMAP * screen;
+static A425_TLS BITMAP *current_bitmap = NULL;
 static int screen_refresh_held = 0;
 static FONT _font;
 struct FONT * font = &_font;
@@ -949,6 +950,9 @@ void allegro_exit(void) {
 }
 
 static void draw_into(BITMAP *bitmap){
+	if (current_bitmap == bitmap)
+        return;
+
     lazily_create_real_bitmap(bitmap, 0);
     if (al_is_bitmap_locked(bitmap->real))
         al_unlock_bitmap(bitmap->real);

--- a/allegro4/allegro.h
+++ b/allegro4/allegro.h
@@ -4,14 +4,7 @@
 /* FIXME: not sure if stdlib belongs here */
 #include <stdlib.h>
 
-#define BITMAP WIN32BITMAP
 #include <allegro5/allegro.h>
-
-#ifdef ALLEGRO_WINDOWS
-#include <allegro5/allegro_windows.h>
-#endif
-
-#undef BITMAP
 
 #undef AL_FUNC
 #undef AL_VAR

--- a/allegro4/allegro.h
+++ b/allegro4/allegro.h
@@ -76,15 +76,14 @@
 
 #define _mouse_screen screen
 
-// typedef struct BITMAP BITMAP;
-extern int * palette_color;
-extern BITMAP* screen;
-extern PALETTE current_palette;
-extern int current_depth;
+#define current_palette _current_palette
 
 unsigned int _default_ds();
 
-extern int AL_RAND();
+/* default random function definition */
+#ifndef AL_RAND
+   #define AL_RAND() (rand())
+#endif
 
 #define bmp_read8(addr)             (*((uint8_t  *)(addr)))
 #define bmp_write8(addr, c)         (*((uint8_t  *)(addr)) = (c))
@@ -95,7 +94,6 @@ extern int AL_RAND();
 #define OLD_FILESEL_WIDTH   -1
 #define OLD_FILESEL_HEIGHT  -1
 
-#define END_OF_MAIN()
 
 #ifdef __cplusplus
     }

--- a/allegro4/datafile.c
+++ b/allegro4/datafile.c
@@ -392,7 +392,7 @@ static FONT_COLOR_DATA *read_font_mono(PACKFILE *f, int *hmax)
       ALLEGRO_LOCKED_REGION *lock = al_lock_bitmap(mf->bitmaps[i]->real,
         ALLEGRO_PIXEL_FORMAT_ABGR_8888, ALLEGRO_LOCK_WRITEONLY);
       for (y = 0; y < h; y++) {
-          unsigned char *row = lock->data + lock->pitch * y;
+          unsigned char *row = (unsigned char *)lock->data + lock->pitch * y;
           unsigned char *source = dat + pitch * y;
           for (x = 0; x < w; x++) {
               int c = (source[(x >> 3)] & (1 << (7 - (x & 7)))) ? 255 : 0;              

--- a/allegro4/file.c
+++ b/allegro4/file.c
@@ -1893,6 +1893,9 @@ int pack_fclose(PACKFILE *f)
 }
 
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 /* pack_fopen_chunk: 
  *  Opens a sub-chunk of the specified file, for reading or writing depending

--- a/allegro4/file.c
+++ b/allegro4/file.c
@@ -1984,7 +1984,7 @@ PACKFILE *pack_fopen_chunk(PACKFILE *f, int pack)
                return NULL;
             }
             _al_sane_strncpy(chunk->normal.passdata, f->normal.passdata, strlen(f->normal.passdata)+1);
-            chunk->normal.passpos = chunk->normal.passdata + (long)f->normal.passpos - (long)f->normal.passdata;
+            chunk->normal.passpos = chunk->normal.passdata + (f->normal.passpos - f->normal.passdata);
             f->normal.passpos = f->normal.passdata;
          }
          chunk->normal.flags |= PACKFILE_FLAG_OLD_CRYPT;
@@ -2107,7 +2107,7 @@ PACKFILE *pack_fclose_chunk(PACKFILE *f)
       }
 
       if ((f->normal.passpos) && (f->normal.flags & PACKFILE_FLAG_OLD_CRYPT))
-         parent->normal.passpos = parent->normal.passdata + (long)f->normal.passpos - (long)f->normal.passdata;
+         parent->normal.passpos = parent->normal.passdata + (f->normal.passpos - f->normal.passdata);
 
       free_packfile(f);
    }

--- a/allegro4/fsel.c
+++ b/allegro4/fsel.c
@@ -933,7 +933,7 @@ int file_select_ex(AL_CONST char *message, char *path, AL_CONST char *ext, int s
    if (ugetc(get_filename(path))) {
       p = get_extension(path);
       if ((!ugetc(p)) && (ext) && (ugetc(ext)) && (!ustrpbrk(ext, uconvert_ascii(" ,;", tmp)))) {
-         size -= ((long)p - (long)path + ucwidth('.'));
+         size -= p - path + ucwidth('.');
          if (size >= uwidth_max(U_CURRENT) + ucwidth(0)) {  /* do not end with '.' */
             p += usetc(p, '.');
             ustrzcpy(p, size, ext);

--- a/allegro4/gui.c
+++ b/allegro4/gui.c
@@ -592,7 +592,7 @@ static int obj_list_cmp(void const *e1, void const *e2)
  */
 static int cmp_tab(AL_CONST DIALOG *d1, AL_CONST DIALOG *d2)
 {
-   int ret = (int)((AL_CONST unsigned long)d2 - (AL_CONST unsigned long)d1);
+   int ret = d2 - d1;
 
    /* Wrap around if d2 is before d1 in the dialog array. */
    if (ret < 0)
@@ -608,7 +608,7 @@ static int cmp_tab(AL_CONST DIALOG *d1, AL_CONST DIALOG *d2)
  */
 static int cmp_shift_tab(AL_CONST DIALOG *d1, AL_CONST DIALOG *d2)
 {
-   int ret = (int)((AL_CONST unsigned long)d1 - (AL_CONST unsigned long)d2);
+   int ret = d1 - d2;
 
    /* Wrap around if d2 is after d1 in the dialog array. */
    if (ret < 0)

--- a/allegro4/guiproc.c
+++ b/allegro4/guiproc.c
@@ -1365,17 +1365,17 @@ int d_text_list_proc(int msg, DIALOG *d, int c)
                   thisitem = (*(getfuncptr)d->dp)(i, NULL);
                   failure = FALSE;
 
-                  if ((int)((unsigned long)d->dp3) < ustrlen(thisitem)) {
-                     for (a=0; a < (int)((unsigned long)d->dp3); a++) {
+                  if ((intptr_t)d->dp3 < ustrlen(thisitem)) {
+                     for (a=0; a < (intptr_t)d->dp3; a++) {
                         if (utolower(ugetat(thisitem, a)) != utolower(ugetat(selected, a))) {
                            failure = TRUE;
                            break;
                         }
                      }
 
-                     if ((!failure) && (utolower(ugetat(thisitem, (int)(unsigned long)d->dp3)) == utolower(c))) {
+                     if ((!failure) && (utolower(ugetat(thisitem, (intptr_t)d->dp3)) == utolower(c))) {
                         d->d1 = i;
-                        d->dp3 = (void *)((unsigned long)d->dp3 + 1);
+                        d->dp3 = (char*)d->dp3 + 1;
 
                         if (sel) {
                            for (i=0; i<listsize; i++)

--- a/allegro4/include/base.h
+++ b/allegro4/include/base.h
@@ -26,9 +26,6 @@
 #define AL_ARRAY(type, name)                    extern type name[]
 #define AL_ID(a,b,c,d)     (((a)<<24) | ((b)<<16) | ((c)<<8) | (d))
 #define ZERO_SIZE_ARRAY(type, name)  type name[]
-#define LOCK_FUNCTION(_)
-#define LOCK_VARIABLE(_)
-#define END_OF_FUNCTION(_)
 
 extern int * allegro_errno;
 

--- a/allegro4/include/base.h
+++ b/allegro4/include/base.h
@@ -10,20 +10,58 @@
 
 #include "internal/alconfig.h"
 
-#define AL_FUNC(type, name, args)               type name args
+#ifdef ALLEGRO_WINDOWS
+   #ifdef ALLEGRO_NO_MAGIC_MAIN
+      #define main _mangled_main
+      #undef END_OF_MAIN
+
+      #ifdef __cplusplus
+extern "C" int __stdcall WinMain(void *hInst, void *hPrev, char *Cmd, int nShow);
+      #endif
+
+      #define END_OF_MAIN()                                                                        \
+                                                                                                   \
+         int __stdcall WinMain(void *hInst, void *hPrev, char *Cmd, int nShow) {                   \
+            return _WinMain((void *)_mangled_main, hInst, hPrev, Cmd, nShow);                      \
+         }
+   #else
+      #define END_OF_MAIN()
+   #endif
+
+   #undef _AL_DLL
+   #if !defined(ALLEGRO425_STATICLINK)
+      #ifdef ALLEGRO425_SOURCE
+         #define _AL_DLL __declspec(dllexport)
+      #else
+         #define _AL_DLL __declspec(dllimport)
+         #undef AL_INLINE
+         #define AL_INLINE(type, name, args, code) inline type name args code
+      #endif
+   #else
+      #define _AL_DLL
+   #endif
+#else
+   #define END_OF_MAIN()
+   #define _AL_DLL
+#endif
+
+#define AL_FUNC(type, name, args)               _AL_DLL type name args
 #ifdef AL_CONST
 #undef AL_CONST
 #endif
 #define AL_CONST const
 
-#define AL_VAR(type, name) extern type name
+#define AL_VAR(type, name) extern _AL_DLL type name
 #ifndef AL_INLINE
-#define AL_INLINE(type, name, args, code)       inline type name args code;
+#define AL_INLINE(type, name, args, code)       inline type name args code
 #endif
+#ifdef ALLEGRO_MSVC
+#define AL_PRINTFUNC(type, name, args, a, b)    AL_FUNC(type, name, args)
+#else
 #define AL_PRINTFUNC(type, name, args, a, b)    AL_FUNC(type, name, args) __attribute__ ((format (printf, a, b)))
-#define AL_FUNCPTR(type, name, args)            extern type (*name) args
-#define AL_METHOD(type, name, args)             type (*name) args
-#define AL_ARRAY(type, name)                    extern type name[]
+#endif
+#define AL_FUNCPTR(type, name, args)            extern _AL_DLL type (*name) args
+#define AL_ARRAY(type, name)                    extern _AL_DLL type name[]
 #define AL_ID(a,b,c,d)     (((a)<<24) | ((b)<<16) | ((c)<<8) | (d))
 #define ZERO_SIZE_ARRAY(type, name)  type name[]
 

--- a/allegro4/include/gfx.h
+++ b/allegro4/include/gfx.h
@@ -431,10 +431,6 @@ AL_FUNC(void, add_clip_rect, (BITMAP *bitmap, int x1, int y_1, int x2, int y2));
 AL_FUNC(void, clear_bitmap, (BITMAP *bitmap));
 AL_FUNC(void, clear, (BITMAP * bitmap));
 AL_FUNC(void, vsync, (void));
-int bitmap_color_depth(BITMAP * bitmap);
-void blit(BITMAP * from, BITMAP * to, int from_x, int from_y, int to_x, int to_y, int width, int height);
-void clear_to_color(BITMAP *bitmap, int color);
-int bitmap_mask_color(BITMAP *bitmap);
 
 /* Bitfield for relaying graphics driver type information */
 #define GFX_TYPE_UNKNOWN     0

--- a/allegro4/include/internal/aintern.h
+++ b/allegro4/include/internal/aintern.h
@@ -27,6 +27,11 @@
    extern "C" {
 #endif
 
+#ifdef ALLEGRO_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#define NOGDI
+#include <windows.h>
+#endif
 
 /* length in bytes of the cpu_vendor string */
 #define _AL_CPU_VENDOR_SIZE 32

--- a/allegro4/include/internal/aintern.h
+++ b/allegro4/include/internal/aintern.h
@@ -31,6 +31,13 @@
 /* length in bytes of the cpu_vendor string */
 #define _AL_CPU_VENDOR_SIZE 32
 
+/* define ALLEGRO425_ONETHREAD if only one thread will be drawing at a time
+ * to current_bitmap etc */
+#ifdef ALLEGRO425_ONETHREAD
+   #define A425_TLS
+#else
+   #define A425_TLS _Thread_local
+#endif
 
 /* flag for how many times we have been initialised */
 AL_VAR(int, _allegro_count);

--- a/allegro4/include/internal/alconfig.h
+++ b/allegro4/include/internal/alconfig.h
@@ -16,6 +16,17 @@
  */
 
 
+ /* fill in default memory locking macros */
+#ifndef END_OF_FUNCTION
+   #define END_OF_FUNCTION(x)
+   #define END_OF_STATIC_FUNCTION(x)
+   #define LOCK_DATA(d, s)
+   #define LOCK_CODE(c, s)
+   #define UNLOCK_DATA(d, s)
+   #define LOCK_VARIABLE(x)
+   #define LOCK_FUNCTION(x)
+#endif
+
 /* fill in default filename behaviour */
 #ifndef ALLEGRO_LFN
    #define ALLEGRO_LFN  1

--- a/allegro4/inline.c
+++ b/allegro4/inline.c
@@ -1,0 +1,3 @@
+#define AL_INLINE(type, name, args, code) type name args code
+
+#include "allegro.h"

--- a/allegro4/inline.c
+++ b/allegro4/inline.c
@@ -1,3 +1,7 @@
-#define AL_INLINE(type, name, args, code) type name args code
+#ifdef _WIN32
+   #define AL_INLINE(type, name, args, code) __declspec(dllexport) type name args code
+#else
+   #define AL_INLINE(type, name, args, code) extern inline type name args code
+#endif
 
 #include "allegro.h"

--- a/allegro4/ufile.c
+++ b/allegro4/ufile.c
@@ -125,7 +125,7 @@ static int ff_match(AL_CONST char *s1, AL_CONST char *s2)
    int index, c1, c2;
 
    /* handle NULL arguments */
-   if ((!s1) && (!s2)) {
+   if (!(s1 && s2)) {
       if (data) {
          _AL_FREE(data);
          data = NULL;

--- a/allegro4/unicode.c
+++ b/allegro4/unicode.c
@@ -27,6 +27,7 @@
 #include <limits.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "allegro.h"
 #include "include/internal/aintern.h"
@@ -736,7 +737,7 @@ int uoffset(AL_CONST char *s, int index)
       }
    }
 
-   return (long)s - (long)orig;
+   return s - orig;
 }
 
 
@@ -1782,7 +1783,7 @@ int ustrsize(AL_CONST char *s)
       last = s;
    } while (ugetxc(&s) != 0);
 
-   return (long)last - (long)orig;
+   return last - orig;
 }
 
 
@@ -1799,7 +1800,7 @@ int ustrsizez(AL_CONST char *s)
    do {
    } while (ugetxc(&s) != 0);
 
-   return (long)s - (long)orig;
+   return s - orig;
 }
 
 
@@ -2312,7 +2313,7 @@ long ustrtol(AL_CONST char *s, char **endp, int base)
    ret = strtol(t, &myendp, base);
 
    if (endp)
-      *endp = (char *)s + uoffset(s, (long)myendp - (long)t);
+      *endp = (char *)s + uoffset(s, myendp - t);
 
    return ret;
 }
@@ -2336,7 +2337,7 @@ double ustrtod(AL_CONST char *s, char **endp)
    ret = strtod(t, &myendp);
 
    if (endp)
-      *endp = (char *)s + uoffset(s, (long)myendp - (long)t);
+      *endp = (char *)s + uoffset(s, myendp - t);
 
    return ret;
 }
@@ -2396,6 +2397,9 @@ typedef struct STRING_ARG
 /* LONGEST:
  *  64-bit integers on platforms that support it, 32-bit otherwise.
  */
+#if INTPTR_MAX == INT64_MAX
+#define LONG_LONG long long
+#endif
 #ifdef LONG_LONG
    #define LONGEST LONG_LONG
 #else
@@ -2947,7 +2951,7 @@ static int decode_format_string(char *buf, STRING_ARG *string_arg, AL_CONST char
 
 	       case 'p':
 		  /* pointer */
-		  slen = sprint_hex(string_arg, &info, FALSE, (unsigned long)(va_arg(args, void *)));
+		  slen = sprint_hex(string_arg, &info, FALSE, (unsigned LONGEST)(va_arg(args, void *)));
 		  NEXT_C();
 		  break;
 

--- a/demos/sopwith/SConscript
+++ b/demos/sopwith/SConscript
@@ -2,4 +2,7 @@ Import('env')
 
 source = Split("""sopwith.cpp""")
 
-env.Program('sopwith', source)
+defines = ['$CPPDEFINES']
+if env['PLATFORM'] == 'win32':
+    defines.extend(['random=rand', 'srandom=srand'])
+env.Program('sopwith', source, CPPDEFINES=defines)

--- a/demos/sopwith/SConscript
+++ b/demos/sopwith/SConscript
@@ -5,4 +5,7 @@ source = Split("""sopwith.cpp""")
 defines = ['$CPPDEFINES']
 if env['PLATFORM'] == 'win32':
     defines.extend(['random=rand', 'srandom=srand'])
+    if 'msvc' in env['TOOLS']:
+        # TODO: Add AL_PI to base.h and replace M_PI with it in demos/sopwith/sopwith.cpp
+        defines.extend(['_USE_MATH_DEFINES'])
 env.Program('sopwith', source, CPPDEFINES=defines)


### PR DESCRIPTION
I have plenty of changes. Let's start with this batch.
- It adds [extensive build testing](https://github.com/mlt/allegro4-to-5/actions). **Note that there is no test runs performed. Just build.** Since most examples a GUI, perhaps AutoHotkey could be used on Windows.
- makes code 64-bit friendly (I used `-Werror=pointer-to-int-cast` with gcc and `/we4311` with VS for testing, but removed them)
- Can build on Windows either with gcc or MSVC
- fixes some typos like in set_config_int and ff_match
- Build shared library with `scons build_shared=1`
- makes AL_INLINE work on all tested platforms even with disabled optimizations
- Early return if draw_into same BITMAP as a5 seems to do lots of other things that we, probably, aren't interested

I'm no expert in scons (I have set up CMake in parallel 😇) , perhaps build can be cleaned up to take proper AddOption and use env.