### PR TITLE
Reimplement PACKFILE on top of ALLEGRO_FILE internals

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -129,7 +129,6 @@ def allegroLibrary():
     else:
         env = defaultEnvironment()
     library = SConscript('allegro4/SConscript', variant_dir = f'{prefix}/allegro', exports = ['env', 'shared'], duplicate = False)
-    Alias('library', library)
     #build = 'build-allegro'
     #env.VariantDir(build, 'allegro4')
     #source = Split("""allegro.c math3d.c math.c file.c unicode.c color.c clip3df.c""")

--- a/allegro4/SConscript
+++ b/allegro4/SConscript
@@ -11,4 +11,6 @@ if (shared):
 else:
 	library = env.StaticLibrary(name, source)
 
+Alias('library', library)
+
 Return('name')

--- a/allegro4/include/datafile.h
+++ b/allegro4/include/datafile.h
@@ -89,10 +89,14 @@ AL_FUNC(void, register_datafile_object, (int id_, AL_METHOD(void *, load, (struc
 AL_FUNC(void, fixup_datafile, (DATAFILE *data));
 
 AL_FUNC(struct BITMAP *, load_bitmap, (AL_CONST char *filename, struct RGB *pal));
-AL_FUNC(struct BITMAP *, load_bmp, (AL_CONST char *filename, struct RGB *pal));
+AL_INLINE(struct BITMAP *, load_bmp, (AL_CONST char *filename, struct RGB *pal),{
+   return load_bitmap(filename, pal);
+});
 AL_FUNC(struct BITMAP *, load_bmp_pf, (PACKFILE *f, struct RGB *pal));
 AL_FUNC(struct BITMAP *, load_lbm, (AL_CONST char *filename, struct RGB *pal));
-AL_FUNC(struct BITMAP *, load_pcx, (AL_CONST char *filename, struct RGB *pal));
+AL_INLINE(struct BITMAP *, load_pcx, (AL_CONST char *filename, struct RGB *pal), {
+   return load_bitmap(filename, pal);
+});
 AL_FUNC(struct BITMAP *, load_pcx_pf, (PACKFILE *f, struct RGB *pal));
 AL_FUNC(struct BITMAP *, load_tga, (AL_CONST char *filename, struct RGB *pal));
 AL_FUNC(struct BITMAP *, load_tga_pf, (PACKFILE *f, struct RGB *pal));
@@ -100,7 +104,9 @@ AL_FUNC(struct BITMAP *, load_tga_pf, (PACKFILE *f, struct RGB *pal));
 AL_FUNC(int, save_bitmap, (AL_CONST char *filename, struct BITMAP *bmp, AL_CONST struct RGB *pal));
 AL_FUNC(int, save_bmp, (AL_CONST char *filename, struct BITMAP *bmp, AL_CONST struct RGB *pal));
 AL_FUNC(int, save_bmp_pf, (PACKFILE *f, struct BITMAP *bmp, AL_CONST struct RGB *pal));
-AL_FUNC(int, save_pcx, (AL_CONST char *filename, struct BITMAP *bmp, AL_CONST struct RGB *pal));
+AL_INLINE(int, save_pcx, (AL_CONST char *filename, struct BITMAP *bmp, AL_CONST struct RGB *pal),{
+   return save_bitmap(filename, bmp, pal);
+})
 AL_FUNC(int, save_pcx_pf, (PACKFILE *f, struct BITMAP *bmp, AL_CONST struct RGB *pal));
 AL_FUNC(int, save_tga, (AL_CONST char *filename, struct BITMAP *bmp, AL_CONST struct RGB *pal));
 AL_FUNC(int, save_tga_pf, (PACKFILE *f, struct BITMAP *bmp, AL_CONST struct RGB *pal));


### PR DESCRIPTION
This is somewhat fragile as it relies on internals of opaque ALLEGRO_FILE, but it allows us to load resources from datfile such as bitmaps and pcx fonts using standard a5 functions such as al_load_bitmap_f.

Also fix broken `scons library` and use shutdown handler that is important with shared libraries at least on Windows.