### PR TITLE
Proper colors on Windows as well as 8 & 32-bit transparency, also polygon using SIMD

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -44,10 +44,12 @@ def defaultEnvironment():
         env.Append(LINKFLAGS=['-rpath', '/opt/homebrew/lib'])
     elif 'msvc' in env['TOOLS']:
         vcpkg_root = os.environ['VCPKG_ROOT'].replace('\\', '/')
-        env.Append(CCFLAGS=['/std:c11']) # if using _Thread_local
+        env.Append(CCFLAGS=['/std:c11', '/arch:AVX'])
         env.Append(CPPDEFINES=['ALLEGRO_NO_MAGIC_MAIN']) # to avoid forcing main() entry point for DLL
         env.Append(CPPPATH=[f'{vcpkg_root}/installed/x64-windows/include'])
         env.Append(LIBPATH=[f'{vcpkg_root}/installed/x64-windows/lib'])
+    else: # neither MSVC nor Apple
+        env.Append(CCFLAGS = ['-mavx'])
 
     if not build_shared:
         env.MergeFlags({'CPPDEFINES': 'ALLEGRO425_STATICLINK'})

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -851,6 +851,9 @@ static void *system_thread_func(ALLEGRO_THREAD * self, void * arg){
 
 static bool start_system_thread(){
     system_thread = al_create_thread(system_thread_func, NULL);
+#if defined(DEBUGMODE) && defined(ALLEGRO_WINDOWS)
+	SetThreadDescription(*(HANDLE*)system_thread, L"Allegro 4 to 5 System Thread");
+#endif
     system_event_queue = al_create_event_queue();
     timer_mutex = al_create_mutex();
     keybuffer_mutex = al_create_mutex();

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -153,7 +153,7 @@ static ALLEGRO_COLOR a5color(int a4color, int bit_depth){
             ((a4color >> 11) & 31) * 255 / 31);
     }
     if (bit_depth == 32){
-        return al_map_rgb(a4color & 255, (a4color >> 8) & 255, (a4color >> 16) & 255);
+        return al_map_rgb(getr32(a4color), getg32(a4color), getb32(a4color));
     }
     /* FIXME: handle other depths */
     return al_map_rgb(1, 1, 1);
@@ -592,6 +592,20 @@ int set_gfx_mode(int card, int width, int height, int virtualwidth, int virtualh
             display = NULL;
         }
         al_register_event_source(system_event_queue, al_get_display_event_source(display));
+
+#ifdef ALLEGRO_WINDOWS
+        ALLEGRO_PIXEL_FORMAT pf = al_get_display_format(display);
+        switch (pf) {
+        case ALLEGRO_PIXEL_FORMAT_ARGB_8888:
+           _rgb_r_shift_32 = 16;
+           _rgb_g_shift_32 = 8;
+           _rgb_b_shift_32 = 0;
+           _rgb_a_shift_32 = 24;
+           break;
+        default:
+           break;
+        }
+#endif
         return 0;
     }
     return -1;
@@ -1336,18 +1350,6 @@ void textout_right(struct BITMAP *bmp, FONT *f, AL_CONST char *str, int x, int y
 void draw_gouraud_sprite(struct BITMAP *bmp, struct BITMAP *sprite, int x, int y, int c1, int c2, int c3, int c4){
     draw_into(bmp);
     al_draw_bitmap(sprite->real, x, y, 0);
-}
-
-int makecol_depth(int depth, int r, int g, int b){
-    switch (depth){
-        case 8: return bestfit_color(current_palette, r>>2, g>>2, b>>2);
-        case 15: return (r >> 3) + ((g >> 3) << 5) + ((b >> 3) << 10);
-        case 16: return (r >> 3) + ((g >> 2) << 5) + ((b >> 3) << 11);
-        case 24: return r + (g << 8) + (b << 16);
-        case 32: return r + (g << 8) + (b << 16) + (255 << 24);
-        /* FIXME: handle 15, 16, 24, 32 */
-        default: return 0;
-    }
 }
 
 void set_clip_rect(BITMAP * bitmap, int x1, int y1, int x2, int y2){

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -290,11 +290,11 @@ void clear_keybuf(){
     al_unlock_mutex(keybuffer_mutex);
 }
 
-void simulate_keypress(int k){
+void simulate_ukeypress(int k, int scancode) {
     al_lock_mutex(keybuffer_mutex);
     if (keybuffer_pos < KEYBUFFER_LENGTH) {
-        keybuffer[keybuffer_pos].unicode = k & 255;
-        keybuffer[keybuffer_pos].keycode = k >> 8;
+        keybuffer[keybuffer_pos].unicode = k;
+        keybuffer[keybuffer_pos].keycode = scancode;
         keybuffer[keybuffer_pos].modifiers = 0;
         keybuffer_pos++;
     }

--- a/allegro4/allegro.c
+++ b/allegro4/allegro.c
@@ -1897,6 +1897,14 @@ int get_color_depth(){
     return current_depth;
 }
 
+int get_desktop_resolution(int *width, int *height) {
+    ALLEGRO_MONITOR_INFO info;
+    al_get_monitor_info(0, &info);
+    *width = info.x2 - info.x1;
+    *height = info.y2 - info.y1;
+    return 0;
+}
+
 void voice_start(int voice){
     /* FIXME */
 }

--- a/allegro4/color.c
+++ b/allegro4/color.c
@@ -160,50 +160,36 @@ int bestfit_color(AL_CONST PALETTE pal, int r, int g, int b)
    return bestfit;
 }
 
-
-int makecol15(int r, int g, int b)
-{
-   return (((r >> 3) << _rgb_r_shift_15) |
-           ((g >> 3) << _rgb_g_shift_15) |
-           ((b >> 3) << _rgb_b_shift_15));
-}
-
-
-int makecol16(int r, int g, int b)
-{
-   return (((r >> 3) << _rgb_r_shift_16) |
-           ((g >> 2) << _rgb_g_shift_16) |
-           ((b >> 3) << _rgb_b_shift_16));
-}
-
-
-int makecol24(int r, int g, int b)
-{
-   return ((r << _rgb_r_shift_24) |
-           (g << _rgb_g_shift_24) |
-           (b << _rgb_b_shift_24));
-}
-
-
-int makecol32(int r, int g, int b)
-{
-   return ((r << _rgb_r_shift_32) |
-           (g << _rgb_g_shift_32) |
-           (b << _rgb_b_shift_32));
-}
-
-
-int makeacol32 (int r, int g, int b, int a)
-{
-   return ((r << _rgb_r_shift_32) |
-           (g << _rgb_g_shift_32) |
-           (b << _rgb_b_shift_32) |
-           (a << _rgb_a_shift_32));
-}
-
 int makecol8(int r, int g, int b)
 {
     return bestfit_color(current_palette, r>>2, g>>2, b>>2);
+}
+
+/* makecol_depth:
+ *  Converts R, G, and B values (ranging 0-255) to whatever pixel format
+ *  is required by the specified color depth.
+ */
+int makecol_depth(int color_depth, int r, int g, int b)
+{
+    switch (color_depth) {
+
+    case 8:
+        return makecol8(r, g, b);
+
+    case 15:
+        return makecol15(r, g, b);
+
+    case 16:
+        return makecol16(r, g, b);
+
+    case 24:
+        return makecol24(r, g, b);
+
+    case 32:
+        return makecol32(r, g, b);
+    }
+
+    return 0;
 }
 
 int makeacol_depth(int color_depth, int r, int g, int b, int a)
@@ -228,102 +214,6 @@ int makeacol_depth(int color_depth, int r, int g, int b, int a)
 
    return 0;
 }
-
-
-AL_INLINE(int, getr8, (int c),
-{
-   return _rgb_scale_6[(int)current_palette[c].r];
-})
-
-
-AL_INLINE(int, getg8, (int c),
-{
-   return _rgb_scale_6[(int)current_palette[c].g];
-})
-
-
-AL_INLINE(int, getb8, (int c),
-{
-   return _rgb_scale_6[(int)current_palette[c].b];
-})
-
-
-AL_INLINE(int, getr15, (int c),
-{
-   return _rgb_scale_5[(c >> _rgb_r_shift_15) & 0x1F];
-})
-
-
-AL_INLINE(int, getg15, (int c),
-{
-   return _rgb_scale_5[(c >> _rgb_g_shift_15) & 0x1F];
-})
-
-
-AL_INLINE(int, getb15, (int c),
-{
-   return _rgb_scale_5[(c >> _rgb_b_shift_15) & 0x1F];
-})
-
-
-AL_INLINE(int, getr16, (int c),
-{
-   return _rgb_scale_5[(c >> _rgb_r_shift_16) & 0x1F];
-})
-
-
-AL_INLINE(int, getg16, (int c),
-{
-   return _rgb_scale_6[(c >> _rgb_g_shift_16) & 0x3F];
-})
-
-
-AL_INLINE(int, getb16, (int c),
-{
-   return _rgb_scale_5[(c >> _rgb_b_shift_16) & 0x1F];
-})
-
-
-AL_INLINE(int, getr24, (int c),
-{
-   return ((c >> _rgb_r_shift_24) & 0xFF);
-})
-
-
-AL_INLINE(int, getg24, (int c),
-{
-   return ((c >> _rgb_g_shift_24) & 0xFF);
-})
-
-
-AL_INLINE(int, getb24, (int c),
-{
-   return ((c >> _rgb_b_shift_24) & 0xFF);
-})
-
-
-AL_INLINE(int, getr32, (int c),
-{
-   return ((c >> _rgb_r_shift_32) & 0xFF);
-})
-
-
-AL_INLINE(int, getg32, (int c),
-{
-   return ((c >> _rgb_g_shift_32) & 0xFF);
-})
-
-
-AL_INLINE(int, getb32, (int c),
-{
-   return ((c >> _rgb_b_shift_32) & 0xFF);
-})
-
-
-AL_INLINE(int, geta32, (int c),
-{
-   return ((c >> _rgb_a_shift_32) & 0xFF);
-})
 
 void set_color(int idx, AL_CONST RGB *p){
     /* TODO */

--- a/allegro4/include/inline/color.inl
+++ b/allegro4/include/inline/color.inl
@@ -23,30 +23,6 @@
    extern "C" {
 #endif
 
-AL_FUNC(int, makecol15, (int r, int g, int b));
-AL_FUNC(int, makecol16, (int r, int g, int b));
-AL_FUNC(int, makecol24, (int r, int g, int b));
-AL_FUNC(int, makecol32, (int r, int g, int b));
-AL_FUNC(int, makeacol32, (int r, int g, int b, int a));
-
-AL_FUNC(int, getr8, (int c));
-AL_FUNC(int, getg8, (int c));
-AL_FUNC(int, getb8, (int c));
-AL_FUNC(int, getr15, (int c));
-AL_FUNC(int, getg15, (int c));
-AL_FUNC(int, getb15, (int c));
-AL_FUNC(int, getr16, (int c));
-AL_FUNC(int, getg16, (int c));
-AL_FUNC(int, getb16, (int c));
-AL_FUNC(int, getr24, (int c));
-AL_FUNC(int, getg24, (int c));
-AL_FUNC(int, getb24, (int c));
-AL_FUNC(int, getr32, (int c));
-AL_FUNC(int, getg32, (int c));
-AL_FUNC(int, getb32, (int c));
-AL_FUNC(int, geta32, (int c));
-
-       /*
 AL_INLINE(int, makecol15, (int r, int g, int b),
 {
    return (((r >> 3) << _rgb_r_shift_15) |
@@ -192,7 +168,6 @@ AL_INLINE(void, _set_color, (int idx, AL_CONST RGB *p),
 })
 
 #endif
-*/
 
 
 #ifdef __cplusplus

--- a/allegro4/include/keyboard.h
+++ b/allegro4/include/keyboard.h
@@ -61,8 +61,10 @@ AL_VAR(int, key_led_flag);
 AL_FUNC(int, keypressed, (void));
 AL_FUNC(int, readkey, (void));
 AL_FUNC(int, ureadkey, (int *scancode));
-AL_FUNC(void, simulate_keypress, (int keycode));
 AL_FUNC(void, simulate_ukeypress, (int keycode, int scancode));
+AL_INLINE(void, simulate_keypress, (int keycode), {
+   simulate_ukeypress(keycode & 255, keycode >> 8);
+});
 AL_FUNC(void, clear_keybuf, (void));
 AL_FUNC(void, set_leds, (int leds));
 AL_FUNC(void, set_keyboard_rate, (int delay, int repeat));

--- a/allegro4/include/system.h
+++ b/allegro4/include/system.h
@@ -205,6 +205,8 @@ AL_VAR(SYSTEM_DRIVER, system_none);
 AL_VAR(SYSTEM_DRIVER *, system_driver);
 
 AL_FUNC(void, set_window_title, (AL_CONST char *name));
+AL_FUNC(int, desktop_color_depth, (void));
+AL_FUNC(int, get_desktop_resolution, (int *width, int *height));
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Here are few more functions and fixes:
- Implement polygon() with translation from int to float using AVX (4 x,y pairs at a time)
- Correct ARGB on Windows as well as transparency in 8 and 32-bit modes. **Other modes were not tested or altered.**
  - Use SIMD to shuffle and transform components in 32-bit mode. [Benchmarks (almost 7.5 times faster compared to direct components extraction and al_map_rgba that uses LUT)](https://gist.github.com/mlt/2713e66ddc2297b581459bab909b7967)
- simulate_ukeypress
- get_desktop_resolution for default/first monitor
- missing export for desktop_color_depth
- friendly name for system thread while debugging on Windows